### PR TITLE
Updated installation instructions to use latest version and requesting version tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Editor. Note: this will add a scoped registry to your project.
 ```json
 {
   "dependencies": {
-    "com.discord.game-sdk": "2.5.6"
+    "com.discord.game-sdk": "3.1.0"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
**Description**

Updated installation instructions to use latest version, and requesting version tagging to latest release points.

**Details**

- Updated README installation instructions to use latest version (3.1.0).
- Requesting adding missing version tags v2.5.6 and v3.1.0 to corresponding commits (see notes below).

**Notes**

Since it might be the case that tags cannot be committed along with the pull request, I'm requesting that the repository maintainer @james7132 adds the tags described above (v2.5.6 and v3.1.0) to corresponding commits.

- v2.5.6 commit SHA: 1144bcb00a22a963d4657656de89dc22c4a8a9e1
- v3.1.0 commit SHA: 02bb804c67b98dfb26fda79eb2bc197bdbb59403

Thank you! Much appreciated! 